### PR TITLE
Authorisation process fixes

### DIFF
--- a/theCodingCompany/oAuth.php
+++ b/theCodingCompany/oAuth.php
@@ -90,7 +90,7 @@ trait oAuth
         );
         //Check and set our credentials
         if(!empty($config) && isset($config["client_id"]) && isset($config["client_secret"])){
-            array_merge($this->credentials, $config);
+            $this->credentials = array_merge($this->credentials, $config);
             return $this->credentials;
         }else{
             return false;


### PR DESCRIPTION
The result of `array_merge` was not being put back into `$this->credentials`, which caused the credentials to not be saved or returned. This was therefore causing incorrect generation of the auth URL.